### PR TITLE
Use the RIDGEBACK_CONFIG envar as the default config

### DIFF
--- a/ridgeback_viz/launch/view_model.launch
+++ b/ridgeback_viz/launch/view_model.launch
@@ -1,6 +1,6 @@
 <launch>
   <!-- Ridgeback configuration to view. See ridgeback_description for details. -->
-  <arg name="config" default="base"/>
+  <arg name="config" default="$(optenv RIDGEBACK_CONFIG base)"/>
 
   <include file="$(find ridgeback_description)/launch/description.launch">
     <arg name="config" value="$(arg config)" />


### PR DESCRIPTION
When viewing the model of a customized ridgeback, if the customized URDF has LMS1xx lidars enabled, the `base` config causes the description to crash: two links wind up being named `front_laser`.
Using the envar we can at least set `RIDGEBACK_CONFIG` to `empty` as well as setting the `URDF_EXTRAS` path to reliably view the model.